### PR TITLE
WIP: add regex replacements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,14 @@ exclude = [".gitignore", ".travis.yml"]
 [badges]
 travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 
+[features]
+default = []
+regex-replace = ["regex"]
+
 [dependencies]
 actix-service = "0.4"
 actix-web = "1.0.0"
 futures = "0.1"
 prometheus = "0.7"
+regex = { version = "1.3.1", optional = true }
+log = "0.4.8"


### PR DESCRIPTION
This allows users to specify a set of regexes that should be replaced in the path, to avoid having a gigantic set of metrics when the path contains resource IDs