### PR TITLE
Update actix-web to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-prom"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Norberto Lopes <nlopes.ml@gmail.com>"]
 edition = "2018"
 description = "Actix-web middleware to expose Prometheus metrics"
@@ -16,7 +16,10 @@ exclude = [".gitignore", ".travis.yml"]
 travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 
 [dependencies]
-actix-service = "0.4"
-actix-web = "1.0.0"
-futures = "0.1"
+actix-service = "1.0"
+actix-web = "2.0.0"
+futures = "0.3"
 prometheus = "0.7"
+
+[dev-dependencies]
+actix-rt = "1.0.0"


### PR DESCRIPTION
Updates:

- futures to 0.3
- actix-service to 1.0
- actix-web-prom middleware 
- tests 
- doc and README examples

Also bumps package version to 0.2