### PR TITLE
Disable default protobuf feature in prometheus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 actix-service = "1.0"
 actix-web = "2.0.0"
 futures = "0.3"
-prometheus = "0.7"
+
+[dependencies.prometheus]
+default-features = false
+version = "0.7.0"
 
 [dev-dependencies]
 actix-rt = "1.0.0"


### PR DESCRIPTION
Protobuf support was removed from Prometheus, so there is no need to have it enabled (but it still is the only default feature in `prometheus` crate).

This allows to have less dependencies to compile without loosing anything.