### PR TITLE
Bump actix-web to 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,11 @@ travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 
 [dependencies]
 actix-service = "1.0.6"
-actix-web = "3.0.0-beta.3"
-actix-http = "2.0.0-beta.3"
+actix-web = "3.0.0"
+actix-http = "2.0.0"
 futures = "0.3.5"
 pin-project = "0.4.8"
 
 [dependencies.prometheus]
 default-features = false
 version = "0.10.0"
-
-[dev-dependencies]
-actix-rt = "1.1.1"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fn health() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let mut labels = HashMap::new();
     labels.insert("label1".to_string(), "value1".to_string());
@@ -106,7 +106,7 @@ fn health(counter: web::Data<IntCounterVec>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let prometheus = PrometheusMetrics::new("api", Some("/metrics"), None);
 
@@ -140,7 +140,7 @@ If that's the case, you might want to use your own registry:
 ```rust
 use actix_web::{web, App, HttpResponse, HttpServer};
 use actix_web_prom::PrometheusMetrics;
-use actix_rt::System;
+use actix_web::rt::System;
 use prometheus::Registry;
 use std::thread;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ fn health() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let mut labels = HashMap::new();
     labels.insert("label1".to_string(), "value1".to_string());
@@ -100,7 +100,7 @@ fn health(counter: web::Data<IntCounterVec>) -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
-#[actix_rt::main]
+#[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let prometheus = PrometheusMetrics::new("api", Some("/metrics"), None);
 
@@ -134,7 +134,7 @@ If that's the case, you might want to use your own registry:
 ```rust
 use actix_web::{web, App, HttpResponse, HttpServer};
 use actix_web_prom::PrometheusMetrics;
-use actix_rt::System;
+use actix_web::rt::System;
 use prometheus::Registry;
 use std::thread;
 
@@ -488,6 +488,7 @@ impl<B: MessageBody> MessageBody for StreamLog<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::rt as actix_rt;
     use actix_web::test::{call_service, init_service, read_body, read_response, TestRequest};
     use actix_web::{web, App, HttpResponse};
 


### PR DESCRIPTION
3.0 is now released. Removed `actix_rt` from dev dependencies since it is now re-exported as `actix_web::rt`.