### PR TITLE
Export metrics with content-type text/plain

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ async fn main() -> std::io::Result<()> {
 
 Using the above as an example, a few things are worth mentioning:
  - `api` is the metrics namespace
- - `/metrics` will be auto exposed (GET requests only)
+ - `/metrics` will be auto exposed (GET requests only) with Content-Type header `content-type: text/plain; version=0.0.4; charset=utf-8`
  - `Some(labels)` is used to add fixed labels to the metrics; `None` can be passed instead
   if no additional labels are necessary.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use actix_http::http::{header::CONTENT_TYPE, HeaderValue};
 use actix_service::{Service, Transform};
-use actix_http::http::header::CONTENT_TYPE;
-use actix_http::http::HeaderValue;
 use actix_web::{
     dev::{Body, BodySize, MessageBody, ResponseBody, ServiceRequest, ServiceResponse},
     http::{Method, StatusCode},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,7 @@ where
             // the middleware and tell us what the endpoint should be.
             if inner.matches(&path, &method) {
                 head.status = StatusCode::OK;
+                head.headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"));
                 body = ResponseBody::Other(Body::from_message(inner.metrics()));
             }
             ResponseBody::Body(StreamLog {
@@ -447,6 +448,8 @@ where
 
 use pin_project::{pin_project, pinned_drop};
 use std::marker::PhantomData;
+use actix_http::http::header::CONTENT_TYPE;
+use actix_http::http::HeaderValue;
 
 #[doc(hidden)]
 #[pin_project(PinnedDrop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,10 @@ where
             // the middleware and tell us what the endpoint should be.
             if inner.matches(&path, &method) {
                 head.status = StatusCode::OK;
-                head.headers.insert(CONTENT_TYPE, HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"));
+                head.headers.insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+                );
                 body = ResponseBody::Other(Body::from_message(inner.metrics()));
             }
             ResponseBody::Body(StreamLog {
@@ -446,10 +449,10 @@ where
     }
 }
 
-use pin_project::{pin_project, pinned_drop};
-use std::marker::PhantomData;
 use actix_http::http::header::CONTENT_TYPE;
 use actix_http::http::HeaderValue;
+use pin_project::{pin_project, pinned_drop};
+use std::marker::PhantomData;
 
 #[doc(hidden)]
 #[pin_project(PinnedDrop)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,8 @@ use std::sync::Arc;
 use std::time::SystemTime;
 
 use actix_service::{Service, Transform};
+use actix_http::http::header::CONTENT_TYPE;
+use actix_http::http::HeaderValue;
 use actix_web::{
     dev::{Body, BodySize, MessageBody, ResponseBody, ServiceRequest, ServiceResponse},
     http::{Method, StatusCode},
@@ -449,8 +451,6 @@ where
     }
 }
 
-use actix_http::http::header::CONTENT_TYPE;
-use actix_http::http::HeaderValue;
 use pin_project::{pin_project, pinned_drop};
 use std::marker::PhantomData;
 


### PR DESCRIPTION
Hi,

Exported metrics for some reason have Content-type header "application/json" - I've tested this on several projects using actix-web 3 and actix-web-prom 0.5.0.
It should be "text/plain; version=0.0.4" with charset "utf-8" as described in prometheus docs here: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format