### PR TITLE
Fix dependency info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ First add `actix_web_prom` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-actix_web_prom = "0.5"
+actix-web-prom = "0.5"
 ```
 
 You then instantiate the prometheus middleware and pass it to `.wrap()`:


### PR DESCRIPTION
This MR fixes the crate name in the example code provided in the `README.md` file.

Instead of `actix_web_prom` it should be `actix-web-prom`. Otherwise cargo can't find the crate.