### PR TITLE
Add ability to exclude paths from metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ actix-http = "^2.1"
 futures = "^0.3"
 pin-project = "^1.0"
 prometheus = { version = "^0.11", default-features = false }
+regex = "^1.4"


### PR DESCRIPTION
This is largely a clone of the Actix Logger middleware's
`exclude` and `exclude_regex` APIs.