### PR TITLE
Remove explicit usage for actix-http and actix-service dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ exclude = [".gitignore", ".travis.yml"]
 travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 
 [dependencies]
-actix-service = "^1.0"
 actix-web = { version = "^3.2", default-features = false }
-actix-http = "^2.1"
 futures = "^0.3"
 pin-project = "^1.0"
 prometheus = { version = "^0.11", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,11 +209,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use actix_http::http::{header::CONTENT_TYPE, HeaderValue};
-use actix_service::{Service, Transform};
 use actix_web::{
-    dev::{Body, BodySize, MessageBody, ResponseBody, ServiceRequest, ServiceResponse},
-    http::{Method, StatusCode},
+    dev::{
+        Body, BodySize, MessageBody, ResponseBody, Service, ServiceRequest, ServiceResponse,
+        Transform,
+    },
+    http::{header::CONTENT_TYPE, HeaderValue, Method, StatusCode},
     web::Bytes,
     Error,
 };


### PR DESCRIPTION
These dependencies can be imported using actix-web.
It will helps to have more coherent versions usage of actix-* modules
and stop users of actix-web-prom to have explicit need for actix-http
and actix-services.