### PR TITLE
Updated to support actix-web 4.0.0-beta.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-prom"
-version = "0.5.1"
+version = "0.6.0-beta.9"
 authors = ["Norberto Lopes <nlopes.ml@gmail.com>"]
 edition = "2018"
 description = "Actix-web middleware to expose Prometheus metrics"
@@ -16,7 +16,8 @@ exclude = [".gitignore", ".travis.yml"]
 travis-ci = { repository = "nlopes/actix-web-prom", branch = "master" }
 
 [dependencies]
-actix-web = { version = "^3.2", default-features = false }
+actix-web = { version = "4.0.0-beta.9", default-features = false }
+actix-http = { version = "3.0.0-beta.10", default-features = false }
 futures = "^0.3"
 pin-project = "^1.0"
 prometheus = { version = "^0.12", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,6 @@ use actix_web::{
     web::Bytes,
     Error,
 };
-use actix_http::Error as HttpError;
 use futures::{
     future::{ok, Ready},
     task::{Context, Poll},
@@ -586,7 +585,7 @@ impl<B> PinnedDrop for StreamLog<B> {
 impl<B: MessageBody> MessageBody for StreamLog<B>
     where actix_http::Error: From<<B as MessageBody>::Error>
 {
-    type Error = HttpError;
+    type Error = actix_http::Error;
 
     fn size(&self) -> BodySize {
         self.body.size()


### PR DESCRIPTION
Most are pretty mechanistic changes to accommodate the updates to the API in v4. One quirk is that `MessageBody` demands the error type to be `actix_http::Error` as [it's implementation of `MessageBody for ResponseBody<B>`](https://docs.rs/actix-http/3.0.0-beta.10/actix_http/body/trait.MessageBody.html#impl-MessageBody-2) puts a `From<actix_http::Error>` constraint on the body. 

It might be useful to release this as a beta release in order to unblock people willing to use actix v4 for it's latest Tokio support.