### PR TITLE
feat: improve compatibility with anyhow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl PrometheusMetricsBuilder {
     }
 
     /// Instantiate PrometheusMetrics struct
-    pub fn build(self) -> Result<PrometheusMetrics, Box<dyn std::error::Error>> {
+    pub fn build(self) -> Result<PrometheusMetrics, Box<dyn std::error::Error + Send + Sync>> {
         let http_requests_total_opts =
             Opts::new("http_requests_total", "Total number of HTTP requests")
                 .namespace(&self.namespace)


### PR DESCRIPTION
Anyhow can work with boxed errors, but only of they are also Send and Sync.

Both traits are implemented by error used anyway, so they just need to be declared,
to make this crate work with anyhow out of the box.