### PR TITLE
Add registry_ref to allow to register default prometheus registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ api_http_requests_total{endpoint="/metrics",label1="value1",method="GET",status=
 You instantiate `PrometheusMetrics` and then use its `.registry` to register your custom
 metric (in this case, we use a `IntCounterVec`).
 
+You can also register default prometheus registry with `.registry(prometheus::default_registry())`
+And use lazy_static global metrics
+
 Then you can pass this counter through `.data()` to have it available within the resource
 responder.
 

--- a/examples/custom_metrics.rs
+++ b/examples/custom_metrics.rs
@@ -20,6 +20,7 @@ async fn main() -> std::io::Result<()> {
     let counter = IntCounterVec::new(counter_opts, &["endpoint", "method", "status"]).unwrap();
     prometheus
         .registry
+        .as_ref()
         .register(Box::new(counter.clone()))
         .unwrap();
 


### PR DESCRIPTION
This change breaks the API slightly - users need to access registry by `.registry.as_ref()` instead of just `.registry`