### PR TITLE
Configurable metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,20 @@ web::resource("/posts/{language}/{slug}")
 
 See the full example `with_cardinality_on_params.rs`.
 
+### Configurable metric names
+
+If you want to rename the default metrics, you can use `ActixMetricsConfiguration` to do so.
+
+```rust
+use actix_web_prom::{PrometheusMetricsBuilder, ActixMetricsConfiguration};
+
+PrometheusMetricsBuilder::new("api")
+    .endpoint("/metrics")
+    .metrics_configuration(
+        ActixMetricsConfiguration::default()
+        .http_requests_duration_seconds_name("my_http_request_duration"),
+    )
+    .build()
+    .unwrap();
+```
+See full example `confuring_default_metrics.rs`.

--- a/examples/configuring_default_metrics.rs
+++ b/examples/configuring_default_metrics.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+use actix_web::{web, App, HttpResponse, HttpServer};
+use actix_web_prom::{ActixMetricsConfiguration, PrometheusMetricsBuilder};
+
+async fn health() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let prometheus = PrometheusMetricsBuilder::new("api")
+        .endpoint("/metrics")
+        .metrics_configuration(
+            ActixMetricsConfiguration::default()
+                .http_requests_duration_seconds_name("my_http_request_duration"),
+        )
+        .build()
+        .unwrap();
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(prometheus.clone())
+            .service(web::resource("/health").to(health))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await?;
+    Ok(())
+}

--- a/examples/configuring_default_metrics.rs
+++ b/examples/configuring_default_metrics.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use actix_web::{web, App, HttpResponse, HttpServer};
 use actix_web_prom::{ActixMetricsConfiguration, PrometheusMetricsBuilder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,6 +417,7 @@ pub struct LabelsConfiguration {
 }
 
 impl LabelsConfiguration {
+    /// construct default LabelsConfiguration
     pub fn default() -> LabelsConfiguration {
         LabelsConfiguration {
             endpoint: String::from("endpoint"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1341,7 +1341,7 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",label1=\"value1\",
     }
 
     #[actix_web::test]
-    async fn middleware_metircs_configuration() {
+    async fn middleware_metrics_configuration() {
         let metrics_config = ActixMetricsConfiguration::new(
             ActixMetric::new("my_http_requests_total", vec!["path", "method", "status"]),
             ActixMetric::new("my_http_request_duration", vec!["path", "method", "status"]),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ pub struct LabelsConfiguration {
 }
 
 impl LabelsConfiguration {
-    fn default() -> LabelsConfiguration {
+    pub fn default() -> LabelsConfiguration {
         LabelsConfiguration {
             endpoint: String::from("endpoint"),
             method: String::from("method"),
@@ -471,7 +471,7 @@ pub struct ActixMetricsConfiguration {
 
 impl ActixMetricsConfiguration {
     /// Create the default metrics configuration
-    fn default() -> ActixMetricsConfiguration {
+    pub fn default() -> ActixMetricsConfiguration {
         ActixMetricsConfiguration {
             http_requests_total_name: String::from("http_requests_total"),
             http_requests_duration_seconds_name: String::from("http_requests_duration_seconds"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,17 +466,6 @@ impl ActixMetricsConfiguration {
         }
     }
 
-    /// Create new metrics configuration with given input
-    pub fn new(
-        http_requests_total: ActixMetric,
-        http_requests_duration_seconds: ActixMetric,
-    ) -> ActixMetricsConfiguration {
-        ActixMetricsConfiguration {
-            http_requests_total,
-            http_requests_duration_seconds,
-        }
-    }
-
     /// Set configs for http_requests_total metric
     pub fn http_requests_total(mut self, value: ActixMetric) -> Self {
         self.http_requests_total = value;
@@ -1342,10 +1331,9 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",label1=\"value1\",
 
     #[actix_web::test]
     async fn middleware_metrics_configuration() {
-        let metrics_config = ActixMetricsConfiguration::new(
-            ActixMetric::new("my_http_requests_total", vec!["path", "method", "status"]),
-            ActixMetric::new("my_http_request_duration", vec!["path", "method", "status"]),
-        );
+        let metrics_config = ActixMetricsConfiguration::default()
+            .http_requests_duration_seconds(ActixMetric::new("my_http_request_duration", vec!["path", "method", "status"]))
+            .http_requests_total(ActixMetric::new("my_http_requests_total", vec!["path", "method", "status"]));
 
         let prometheus = PrometheusMetricsBuilder::new("actix_web_prom")
             .endpoint("/metrics")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,7 +360,6 @@ impl PrometheusMetricsBuilder {
 
     /// Instantiate PrometheusMetrics struct
     pub fn build(self) -> Result<PrometheusMetrics, Box<dyn std::error::Error + Send + Sync>> {
-
         let labels_vec = self.metrics_configuration.labels.clone().to_vec();
         let labels = &labels_vec.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
 
@@ -373,10 +372,7 @@ impl PrometheusMetricsBuilder {
         .namespace(&self.namespace)
         .const_labels(self.const_labels.clone());
 
-        let http_requests_total = IntCounterVec::new(
-            http_requests_total_opts,
-            labels
-        )?;
+        let http_requests_total = IntCounterVec::new(http_requests_total_opts, labels)?;
 
         let http_requests_duration_seconds_opts = HistogramOpts::new(
             self.metrics_configuration
@@ -388,10 +384,8 @@ impl PrometheusMetricsBuilder {
         .buckets(self.buckets.to_vec())
         .const_labels(self.const_labels.clone());
 
-        let http_requests_duration_seconds = HistogramVec::new(
-            http_requests_duration_seconds_opts,
-            labels
-        )?;
+        let http_requests_duration_seconds =
+            HistogramVec::new(http_requests_duration_seconds_opts, labels)?;
 
         self.registry
             .register(Box::new(http_requests_total.clone()))?;
@@ -413,7 +407,6 @@ impl PrometheusMetricsBuilder {
     }
 }
 
-
 #[derive(Debug, Clone)]
 ///Configurations for the labels used in metrics
 pub struct LabelsConfiguration {
@@ -426,7 +419,7 @@ pub struct LabelsConfiguration {
 impl LabelsConfiguration {
     fn default() -> LabelsConfiguration {
         LabelsConfiguration {
-            endpoint: String::from("endpoint"), 
+            endpoint: String::from("endpoint"),
             method: String::from("method"),
             status: String::from("status"),
             version: None,
@@ -437,7 +430,7 @@ impl LabelsConfiguration {
         let mut labels = vec![self.endpoint, self.method, self.status];
         if let Some(version) = self.version {
             labels.push(version);
-        }        
+        }
         labels
     }
 
@@ -466,7 +459,6 @@ impl LabelsConfiguration {
     }
 }
 
-
 #[derive(Debug, Clone)]
 /// Configuration for the collected metrics
 ///
@@ -474,7 +466,7 @@ impl LabelsConfiguration {
 pub struct ActixMetricsConfiguration {
     http_requests_total_name: String,
     http_requests_duration_seconds_name: String,
-    labels: LabelsConfiguration
+    labels: LabelsConfiguration,
 }
 
 impl ActixMetricsConfiguration {
@@ -500,7 +492,7 @@ impl ActixMetricsConfiguration {
     }
 
     /// Set name for http_requests_duration_seconds metric
-    pub fn http_requests_duration_seconds_name(mut self, name: &str)-> Self {
+    pub fn http_requests_duration_seconds_name(mut self, name: &str) -> Self {
         self.http_requests_duration_seconds_name = name.to_owned();
         self
     }
@@ -885,9 +877,8 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",method=\"GET\",sta
         let prometheus = PrometheusMetricsBuilder::new("actix_web_prom")
             .endpoint("/metrics")
             .metrics_configuration(
-                ActixMetricsConfiguration::default().labels(
-                    LabelsConfiguration::default().version("version")
-                )
+                ActixMetricsConfiguration::default()
+                    .labels(LabelsConfiguration::default().version("version")),
             )
             .build()
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,13 +492,10 @@ impl ActixMetricsConfiguration {
         }
     }
 
-    /// Create the default metrics configuration with custom labels configuration
-    pub fn default_with_custom_labels(labels: LabelsConfiguration) -> ActixMetricsConfiguration {
-        ActixMetricsConfiguration {
-            http_requests_total_name: String::from("http_requests_total"),
-            http_requests_duration_seconds_name: String::from("http_requests_duration_seconds"),
-            labels: labels,
-        }
+    /// Set the labels collected for the metrics
+    pub fn labels(mut self, labels: LabelsConfiguration) -> Self {
+        self.labels = labels;
+        self
     }
 
     /// Set name for http_requests_total metric
@@ -893,7 +890,7 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",method=\"GET\",sta
         let prometheus = PrometheusMetricsBuilder::new("actix_web_prom")
             .endpoint("/metrics")
             .metrics_configuration(
-                ActixMetricsConfiguration::default_with_custom_labels(
+                ActixMetricsConfiguration::default().labels(
                     LabelsConfiguration::default().version("version")
                 )
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,11 +398,6 @@ impl PrometheusMetricsBuilder {
         self.registry
             .register(Box::new(http_requests_duration_seconds.clone()))?;
 
-        let enabled_http_version_label = match self.metrics_configuration.labels.version {
-            Some(_) => true,
-            None => false
-        };
-
         Ok(PrometheusMetrics {
             http_requests_total,
             http_requests_duration_seconds,
@@ -413,7 +408,7 @@ impl PrometheusMetricsBuilder {
             exclude: self.exclude,
             exclude_regex: self.exclude_regex,
             exclude_status: self.exclude_status,
-            enable_http_version_label: enabled_http_version_label,
+            enable_http_version_label: self.metrics_configuration.labels.version.is_some(),
         })
     }
 }
@@ -440,9 +435,9 @@ impl LabelsConfiguration {
 
     fn to_vec(self) -> Vec<String> {
         let mut labels = vec![self.endpoint, self.method, self.status];
-        if self.version.is_some() {
-            labels.push(self.version.unwrap())
-        }
+        if let Some(version) = self.version {
+            labels.push(version);
+        }        
         labels
     }
 


### PR DESCRIPTION
This adds the possibility to rename metrics and the labels. 
The solution is extendable for other possible metric specific configuration as well as adding new metrics.

Example usage to rename a default metric
```rust
use actix_web_prom::{PrometheusMetricsBuilder, ActixMetricsConfiguration};

PrometheusMetricsBuilder::new("api")
    .endpoint("/metrics")
    .metrics_configuration(
        ActixMetricsConfiguration::default()
        .http_requests_duration_seconds_name("my_http_request_duration"),
    )
    .build()
    .unwrap();
```