### PR TITLE
Add ability to exclude paths and statuses from metrics 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ actix-http = "^2.1"
 futures = "^0.3"
 pin-project = "^1.0"
 prometheus = { version = "^0.11", default-features = false }
+regex = "^1.4"


### PR DESCRIPTION
Merged the latest changes into #46 (thanks to @kppullin) and added an extra option to the builder to exclude an entire status code from the metrics. Useful to prevent any DoS vulnerability caused by too many 404s causing the metrics response to grow too large. 

There is probably a better way to achieve that but I couldn't figure out how to get a list of paths from the service and this works for my use case.

Feel free to merge if it's useful or close otherwise.