### PR TITLE
feat: configurable path parameters cardinality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures-core = "0.3"
 pin-project-lite = "0.2"
 prometheus = { version = "0.13", default-features = false }
 regex = "^1.4"
+log = "0.4"
 
 [features]
 process = ["prometheus/process"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ regex = "^1.4"
 
 [features]
 process = ["prometheus/process"]
+strfmt = { version = "0.2.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 exclude = [".gitignore", ".github/", "README.tpl", "examples/"]
 
 [dependencies]
+strfmt = { version = "0.2.4" }
 actix-web = { version = "4.0", default-features = false, features = ["macros"] }
 futures-core = "0.3"
 pin-project-lite = "0.2"
@@ -21,4 +22,3 @@ regex = "^1.4"
 
 [features]
 process = ["prometheus/process"]
-strfmt = { version = "0.2.4" }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ fn main() -> std::io::Result<()> {
 ### Configurable routes pattern cardinality
 
 Let's say you have on your app a route to fetch posts by language and by slug `GET /posts/{language}/{slug}`.
-By default, actix-web-prom will provide metrics for the whole route with the label `endpoint` set to the pattern `/posts/{locale}/{slug}`.
+By default, actix-web-prom will provide metrics for the whole route with the label `endpoint` set to the pattern `/posts/{language}/{slug}`.
 This is great but you cannot differentiate metrics across languages (as there is only a limited set of them).
 Actix-web-prom can be configured to allow for more cardinality on some route params.
 

--- a/README.md
+++ b/README.md
@@ -206,3 +206,29 @@ fn main() -> std::io::Result<()> {
 
 ```
 
+### Configurable routes pattern cardinality
+
+Let's say you have on your app a route to fetch posts by language and by slug `GET /posts/{language}/{slug}`.
+By default, actix-web-prom will provide metrics for the whole route with the label `endpoint` set to the pattern `/posts/{locale}/{slug}`.
+This is great but you cannot differentiate metrics across languages (as there is only a limited set of them).
+Actix-web-prom can be configured to allow for more cardinality on some route params.
+
+For that you need to add a middleware to pass some [extensions data](https://blog.adamchalmers.com/what-are-extensions/), specifically the `MetricsConfig` struct that contains the list of params you want to keep cardinality on.
+
+```rust
+use actix_web::dev::Service;
+use actix_web::HttpMessage;
+use actix_web_prom::MetricsConfig;
+
+web::resource("/posts/{language}/{slug}")
+    .wrap_fn(|req, srv| {
+        req.extensions_mut().insert::<MetricsConfig>(
+            MetricsConfig { cardinality_keep_params: vec!["language".to_string()] }
+        );
+        srv.call(req)
+    })
+    .route(web::get().to(handler));
+```
+
+See the full example `with_cardinality_on_params.rs`.
+

--- a/examples/with_cardinality_on_params.rs
+++ b/examples/with_cardinality_on_params.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
+use actix_web::dev::Service;
+use actix_web::HttpMessage;
+
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
-use actix_web_prom::PrometheusMetricsBuilder;
+use actix_web_prom::{PrometheusMetricsBuilder, MetricsConfig};
 
 
 async fn health() -> HttpResponse {
@@ -27,6 +30,20 @@ async fn main() -> std::io::Result<()> {
             .wrap(prometheus.clone())
             .service(web::resource("/health").to(health))
             .service(
+                web::resource("/services/{service_id}")
+                    .name("Services endpoint")
+                    .wrap_fn(|req, srv| {
+                        // example of a route where we want to keep the details of `service_id` param in the metrics
+                        // we use a middleware to specify that `service_id` param values are kept in the labels
+                        req.extensions_mut().insert::<MetricsConfig>(
+                            MetricsConfig { cardinality_keep_params: vec!["service_id".to_string()] }
+                        );
+                        srv.call(req)
+                    })
+                    .route(web::get().to(get_posts_details))
+            )
+            .service(
+                // example of a route where we want to ignore the cardinality of `post_id` in the metrics
                 web::resource("/posts/{post_id}")
                     .name("Posts endpoint")
                     .route(web::get().to(get_posts_details))
@@ -37,3 +54,4 @@ async fn main() -> std::io::Result<()> {
     .await?;
     Ok(())
 }
+

--- a/examples/with_cardinality_on_params.rs
+++ b/examples/with_cardinality_on_params.rs
@@ -4,8 +4,7 @@ use actix_web::dev::Service;
 use actix_web::HttpMessage;
 
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
-use actix_web_prom::{PrometheusMetricsBuilder, MetricsConfig};
-
+use actix_web_prom::{MetricsConfig, PrometheusMetricsBuilder};
 
 async fn health() -> HttpResponse {
     HttpResponse::Ok().finish()
@@ -35,27 +34,24 @@ async fn main() -> std::io::Result<()> {
                     .wrap_fn(|req, srv| {
                         // example of a route where we want to keep the details of `service_id` param in the metrics
                         // we use a middleware to specify that `service_id` param values are kept in the labels
-                        req.extensions_mut().insert::<MetricsConfig>(
-                            MetricsConfig { cardinality_keep_params: vec!["cheap".to_string()] }
-                        );
+                        req.extensions_mut().insert::<MetricsConfig>(MetricsConfig {
+                            cardinality_keep_params: vec!["cheap".to_string()],
+                        });
                         srv.call(req)
                     })
-                    .route(
-                        web::get()
-                        .to(|path: web::Path<(String, String)>| async {
-                            let (cheap_param, _expensive) = path.into_inner();
-                            if !["foo", "bar"].map(|x| x.to_string()).contains(&cheap_param) {
-                                return HttpResponse::NotFound().finish()
-                            }
-                            HttpResponse::Ok().finish()
-                        })
-                    )
+                    .route(web::get().to(|path: web::Path<(String, String)>| async {
+                        let (cheap_param, _expensive) = path.into_inner();
+                        if !["foo", "bar"].map(|x| x.to_string()).contains(&cheap_param) {
+                            return HttpResponse::NotFound().finish();
+                        }
+                        HttpResponse::Ok().finish()
+                    })),
             )
             .service(
                 // example of a route where we want to ignore the cardinality of `post_id` in the metrics
                 web::resource("/posts/{post_id}")
                     .name("Posts endpoint")
-                    .route(web::get().to(get_posts_details))
+                    .route(web::get().to(get_posts_details)),
             )
     })
     .bind("127.0.0.1:8080")?
@@ -63,4 +59,3 @@ async fn main() -> std::io::Result<()> {
     .await?;
     Ok(())
 }
-

--- a/examples/with_params.rs
+++ b/examples/with_params.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+
+use actix_web::{web, App, HttpResponse, HttpServer, Responder};
+use actix_web_prom::PrometheusMetricsBuilder;
+
+
+async fn health() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+async fn get_posts_details() -> impl Responder {
+    HttpResponse::Ok().json("some details")
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let mut labels = HashMap::new();
+    labels.insert("label1".to_string(), "value1".to_string());
+    let prometheus = PrometheusMetricsBuilder::new("api")
+        .endpoint("/metrics")
+        .const_labels(labels)
+        .build()
+        .unwrap();
+
+    HttpServer::new(move || {
+        App::new()
+            .wrap(prometheus.clone())
+            .service(web::resource("/health").to(health))
+            .service(
+                web::resource("/posts/{post_id}")
+                    .name("Posts endpoint")
+                    .route(web::get().to(get_posts_details))
+            )
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
the idea for this MR was originally discussed in #72 

A change that allow developer to change the cardinality of a given param name for a specific route.

To define a config that goes down the line, we need to use actix `extensions_mut()` method. The external/user developer need to define a middleware that will pass some data down the middleware stack.

Example when defining a route:
```rust
    web::resource("/{source_ids}/{z}/{x}/{y}")
        .wrap_fn(|req, srv| {
            req.extensions_mut().insert::<MetricsConfig>(
                MetricsConfig { cardinality_keep_params: vec!["source_ids".to_string()] }
            );
            srv.call(req)
        })
        .route(web::get().to(get_tile_handler))
```

Feel free to comment or help.
