### PR TITLE
Added http_version label to metrics.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ use actix_web::{
     dev::{self, Service, ServiceRequest, ServiceResponse, Transform},
     http::{
         header::{HeaderValue, CONTENT_TYPE},
-        Method, StatusCode,
+        Method, StatusCode, Version,
     },
     web::Bytes,
     Error,
@@ -248,6 +248,7 @@ pub struct PrometheusMetricsBuilder {
     exclude: HashSet<String>,
     exclude_regex: RegexSet,
     exclude_status: HashSet<StatusCode>,
+    enable_http_version_label: bool,
 }
 
 impl PrometheusMetricsBuilder {
@@ -264,6 +265,7 @@ impl PrometheusMetricsBuilder {
             exclude: HashSet::new(),
             exclude_regex: RegexSet::empty(),
             exclude_status: HashSet::new(),
+            enable_http_version_label: false,
         }
     }
 
@@ -315,6 +317,12 @@ impl PrometheusMetricsBuilder {
         self
     }
 
+    /// Report HTTP version of served request as "http_version" label
+    pub fn enable_http_version_label(mut self, enable: bool) -> Self {
+        self.enable_http_version_label = enable;
+        self
+    }
+
     /// Instantiate PrometheusMetrics struct
     pub fn build(self) -> Result<PrometheusMetrics, Box<dyn std::error::Error + Send + Sync>> {
         let http_requests_total_opts =
@@ -322,8 +330,13 @@ impl PrometheusMetricsBuilder {
                 .namespace(&self.namespace)
                 .const_labels(self.const_labels.clone());
 
-        let http_requests_total =
-            IntCounterVec::new(http_requests_total_opts, &["endpoint", "method", "status"])?;
+        let label_names = if self.enable_http_version_label {
+            ["http_version", "endpoint", "method", "status"].as_slice()
+        } else {
+            ["endpoint", "method", "status"].as_slice()
+        };
+
+        let http_requests_total = IntCounterVec::new(http_requests_total_opts, label_names)?;
 
         let http_requests_duration_seconds_opts = HistogramOpts::new(
             "http_requests_duration_seconds",
@@ -333,10 +346,8 @@ impl PrometheusMetricsBuilder {
         .buckets(self.buckets.to_vec())
         .const_labels(self.const_labels.clone());
 
-        let http_requests_duration_seconds = HistogramVec::new(
-            http_requests_duration_seconds_opts,
-            &["endpoint", "method", "status"],
-        )?;
+        let http_requests_duration_seconds =
+            HistogramVec::new(http_requests_duration_seconds_opts, label_names)?;
 
         self.registry
             .register(Box::new(http_requests_total.clone()))?;
@@ -353,6 +364,7 @@ impl PrometheusMetricsBuilder {
             exclude: self.exclude,
             exclude_regex: self.exclude_regex,
             exclude_status: self.exclude_status,
+            enable_http_version_label: self.enable_http_version_label,
         })
     }
 }
@@ -382,6 +394,7 @@ pub struct PrometheusMetrics {
     pub(crate) exclude: HashSet<String>,
     pub(crate) exclude_regex: RegexSet,
     pub(crate) exclude_status: HashSet<StatusCode>,
+    pub(crate) enable_http_version_label: bool,
 }
 
 impl PrometheusMetrics {
@@ -401,7 +414,14 @@ impl PrometheusMetrics {
         }
     }
 
-    fn update_metrics(&self, path: &str, method: &Method, status: StatusCode, clock: Instant) {
+    fn update_metrics(
+        &self,
+        http_version: Version,
+        path: &str,
+        method: &Method,
+        status: StatusCode,
+        clock: Instant,
+    ) {
         if self.exclude.contains(path)
             || self.exclude_regex.is_match(path)
             || self.exclude_status.contains(&status)
@@ -409,19 +429,39 @@ impl PrometheusMetrics {
             return;
         }
 
-        let method = method.to_string();
-        let status = status.as_u16().to_string();
+        let label_values = [
+            Self::http_version_label(http_version),
+            path,
+            method.as_str(),
+            status.as_str(),
+        ];
+        let label_values = if self.enable_http_version_label {
+            &label_values[..]
+        } else {
+            &label_values[1..]
+        };
 
         let elapsed = clock.elapsed();
         let duration =
             (elapsed.as_secs() as f64) + f64::from(elapsed.subsec_nanos()) / 1_000_000_000_f64;
         self.http_requests_duration_seconds
-            .with_label_values(&[path, &method, &status])
+            .with_label_values(label_values)
             .observe(duration);
 
         self.http_requests_total
-            .with_label_values(&[path, &method, &status])
+            .with_label_values(label_values)
             .inc();
+    }
+
+    fn http_version_label(version: Version) -> &'static str {
+        match version {
+            v if v == Version::HTTP_09 => "HTTP/0.9",
+            v if v == Version::HTTP_10 => "HTTP/1.0",
+            v if v == Version::HTTP_11 => "HTTP/1.1",
+            v if v == Version::HTTP_2 => "HTTP/2.0",
+            v if v == Version::HTTP_3 => "HTTP/3.0",
+            _ => "<unrecognized>",
+        }
     }
 }
 
@@ -474,6 +514,7 @@ where
         let time = *this.time;
         let req = res.request();
         let method = req.method().clone();
+        let version = req.version();
         let pattern_or_path = req
             .match_pattern()
             .unwrap_or_else(|| req.path().to_string());
@@ -500,6 +541,7 @@ where
                     status: head.status,
                     path: pattern_or_path,
                     method,
+                    version,
                 })
             } else {
                 EitherBody::left(StreamLog {
@@ -510,6 +552,7 @@ where
                     status: head.status,
                     path: pattern_or_path,
                     method,
+                    version,
                 })
             }
         })))
@@ -554,6 +597,7 @@ pin_project! {
         status: StatusCode,
         path: String,
         method: Method,
+        version: Version,
     }
 
 
@@ -561,7 +605,7 @@ pin_project! {
         fn drop(this: Pin<&mut Self>) {
             // update the metrics for this request at the very end of responding
             this.inner
-                .update_metrics(&this.path, &this.method, this.status, this.clock);
+                .update_metrics(this.version, &this.path, &this.method, this.status, this.clock);
         }
     }
 }
@@ -640,6 +684,67 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",method=\"GET\",sta
             )
             .unwrap()
         ));
+    }
+
+    #[actix_web::test]
+    async fn middleware_http_version() {
+        let prometheus = PrometheusMetricsBuilder::new("actix_web_prom")
+            .endpoint("/metrics")
+            .enable_http_version_label(true)
+            .build()
+            .unwrap();
+
+        let app = init_service(
+            App::new()
+                .wrap(prometheus)
+                .service(web::resource("/health_check").to(HttpResponse::Ok)),
+        )
+        .await;
+
+        let test_cases = HashMap::from([
+            (Version::HTTP_09, 1),
+            (Version::HTTP_10, 2),
+            (Version::HTTP_11, 5),
+            (Version::HTTP_2, 7),
+            (Version::HTTP_3, 11),
+        ]);
+
+        for (http_version, repeats) in test_cases.iter() {
+            for _ in 0..*repeats {
+                let res = call_service(
+                    &app,
+                    TestRequest::with_uri("/health_check")
+                        .version(*http_version)
+                        .to_request(),
+                )
+                .await;
+                assert!(res.status().is_success());
+                assert_eq!(read_body(res).await, "");
+            }
+        }
+
+        let res = call_service(&app, TestRequest::with_uri("/metrics").to_request()).await;
+        assert_eq!(
+            res.headers().get(CONTENT_TYPE).unwrap(),
+            "text/plain; version=0.0.4; charset=utf-8"
+        );
+        let body = String::from_utf8(read_body(res).await.to_vec()).unwrap();
+        println!("Body: {}", body);
+        for (http_version, repeats) in test_cases {
+            assert!(&body.contains(
+                &String::from_utf8(web::Bytes::from(
+                    format!(
+                        "actix_web_prom_http_requests_duration_seconds_bucket{{endpoint=\"/health_check\",http_version=\"{}\",method=\"GET\",status=\"200\",le=\"0.005\"}} {}
+", PrometheusMetrics::http_version_label(http_version), repeats)
+            ).to_vec()).unwrap()));
+
+            assert!(&body.contains(
+                &String::from_utf8(web::Bytes::from(
+                    format!(
+                        "actix_web_prom_http_requests_total{{endpoint=\"/health_check\",http_version=\"{}\",method=\"GET\",status=\"200\"}} {}
+", PrometheusMetrics::http_version_label(http_version), repeats)
+            ).to_vec()).unwrap()));
+        }
     }
 
     #[actix_web::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ impl PrometheusMetricsBuilder {
         self
     }
 
-    /// Report HTTP version of served request as "http_version" label
+    /// Report HTTP version of served request as "version" label
     pub fn enable_http_version_label(mut self, enable: bool) -> Self {
         self.enable_http_version_label = enable;
         self
@@ -331,7 +331,7 @@ impl PrometheusMetricsBuilder {
                 .const_labels(self.const_labels.clone());
 
         let label_names = if self.enable_http_version_label {
-            ["http_version", "endpoint", "method", "status"].as_slice()
+            ["version", "endpoint", "method", "status"].as_slice()
         } else {
             ["endpoint", "method", "status"].as_slice()
         };
@@ -734,14 +734,14 @@ actix_web_prom_http_requests_total{endpoint=\"/health_check\",method=\"GET\",sta
             assert!(&body.contains(
                 &String::from_utf8(web::Bytes::from(
                     format!(
-                        "actix_web_prom_http_requests_duration_seconds_bucket{{endpoint=\"/health_check\",http_version=\"{}\",method=\"GET\",status=\"200\",le=\"0.005\"}} {}
+                        "actix_web_prom_http_requests_duration_seconds_bucket{{endpoint=\"/health_check\",method=\"GET\",status=\"200\",version=\"{}\",le=\"0.005\"}} {}
 ", PrometheusMetrics::http_version_label(http_version), repeats)
             ).to_vec()).unwrap()));
 
             assert!(&body.contains(
                 &String::from_utf8(web::Bytes::from(
                     format!(
-                        "actix_web_prom_http_requests_total{{endpoint=\"/health_check\",http_version=\"{}\",method=\"GET\",status=\"200\"}} {}
+                        "actix_web_prom_http_requests_total{{endpoint=\"/health_check\",method=\"GET\",status=\"200\",version=\"{}\"}} {}
 ", PrometheusMetrics::http_version_label(http_version), repeats)
             ).to_vec()).unwrap()));
         }


### PR DESCRIPTION
When you provide http service to other services it's important to understand which http version is actually used by calling services. I've introduced additional label to metrics with the http version of served request. So basically how the whole "first" line of http request body like `GET /test HTTP/2` and response status is reflected in metrics. Hope this is not that much breaking change to be rejected. Thanks a lot in advance for a review.