### PR TITLE
feat: add helper middleware to easily define metrics config on a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,23 @@ web::resource("/posts/{language}/{slug}")
 
 See the full example `with_cardinality_on_params.rs`.
 
+Actix-web-prom also provide a helper middleware which is a little bit more compact :
+
+```rust
+use actix_web::{route, HttpRequest, HttpResponse, Result as ActixResult};
+use actix_web_prom::{MetricsConfiguratorMiddleware, MetricsConfig};
+
+#[route(
+    "/posts/{language}/{slug}",
+    method = "GET",
+    method = "HEAD",
+    wrap = "(MetricsConfiguratorMiddleware(MetricsConfig { cardinality_keep_params: vec![\"language\".into()] })).into_middleware()"
+)]
+async fn get_source_info(req: HttpRequest) -> ActixResult<HttpResponse> {
+    Ok(HttpResponse::Ok().into())
+}
+```
+
 ### Configurable metric names
 
 If you want to rename the default metrics, you can use `ActixMetricsConfiguration` to do so.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,11 +339,11 @@ use prometheus::{
 use regex::RegexSet;
 use strfmt::strfmt;
 
-/// MetricsConfig define middleware and config struct to change the behaviour of the metrics
-/// struct to define some particularities
+/// Define optional behaviour of metrics retention for a route or a subset of routes
+/// This MetricsConfig is defined via extensions data
 #[derive(Debug, Clone)]
 pub struct MetricsConfig {
-    /// list of params where the cardinality matters
+    /// list of params where the cardinality is useful and want to be preserved
     pub cardinality_keep_params: Vec<String>,
 }
 


### PR DESCRIPTION
Adding MetricsConfiguratorMiddleware to allow upstream code to
provide a quick way to configure cardinality_keep_params with wrap